### PR TITLE
Removing date format

### DIFF
--- a/src/main/resources/org/opensearch/ubi/backends/events-mapping.json
+++ b/src/main/resources/org/opensearch/ubi/backends/events-mapping.json
@@ -17,7 +17,6 @@
     "message_type": { "type": "keyword" },
     "timestamp": {
       "type": "date",
-      "format": "yyyy-MM-dd HH:mm:ss.SSSSSS||date_time",
       "doc_values": true
     },
     "event_attributes": {


### PR DESCRIPTION
Changing the `timestamp` date format to allow epoch time milliseconds.

The default in OS 2.11 is `strict_date_optional_time||epoch_millis` which is fine. The default in 2.12 is `strict_date_time_no_millis||strict_date_optional_time||epoch_millis`.