### PR TITLE
Exposed query id and HTTP TRACE

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,8 @@ version: '3'
 services:
   opensearch:
     build: ./
-    container_name: opensearch
+    # TODO: maybe rename the demo opensearch node instead
+    container_name: opensearch_ubi  #Chorus demo already has an `opensearch` container
     environment:
       discovery.type: single-node
       node.name: opensearch
@@ -13,8 +14,9 @@ services:
 #      Warning: this is opening it up to all cross domains
 #      http.cors.allow-origin: "http://localhost"...
       http.cors.allow-origin: "*"
-      http.cors.allow-methods: OPTIONS,HEAD,GET,POST,PUT,DELETE
+      http.cors.allow-methods: OPTIONS,TRACE,HEAD,GET,POST,PUT,DELETE
       http.cors.allow-credentials: true
+      # TODO: add REST headers required here
       http.cors.allow-headers: X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
       plugins.ubi.indices: "awesome"
       logger.level: info

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,8 +3,7 @@ version: '3'
 services:
   opensearch:
     build: ./
-    # TODO: maybe rename the demo opensearch node instead
-    container_name: opensearch_ubi  #Chorus demo already has an `opensearch` container
+    container_name: opensearch_ubi 
     environment:
       discovery.type: single-node
       node.name: opensearch
@@ -16,7 +15,6 @@ services:
       http.cors.allow-origin: "*"
       http.cors.allow-methods: OPTIONS,TRACE,HEAD,GET,POST,PUT,DELETE
       http.cors.allow-credentials: true
-      # TODO: add REST headers required here
       http.cors.allow-headers: X-Requested-With,X-Auth-Token,Content-Type,Content-Length,Authorization
       plugins.ubi.indices: "awesome"
       logger.level: info

--- a/documentation.md
+++ b/documentation.md
@@ -49,6 +49,7 @@ The plugin exposes a REST API.
 | `DELETE` | `/_plugins/ubi/{store}` | Delete a backend store |
 | `GET` | `/_plugins/ubi` | Get a list of all stores |
 | `POST` | `/_plugins/ubi/{store}` | Index events into the store |
+| `TRACE` | `/_plugins/ubi` | For temporary developer debugging  |
 
 ### Creating a Store
 

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -106,9 +106,9 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
                         LOGGER.error("Unable to persist query.", ex);
                     }
 
+                    LOGGER.warn("######### Setting and exposing query_id {}", queryId);
+                    threadPool.getThreadContext().addResponseHeader("Access-Control-Expose-Headers", "query_id");
                     threadPool.getThreadContext().addResponseHeader("query_id", queryId);
-
-                    //}
 
                     final long elapsedTime = System.currentTimeMillis() - startTime;
                     LOGGER.info("UBI search request filter took {} ms", elapsedTime);

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -111,7 +111,9 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
                     }
 
                     LOGGER.info("######### Setting and exposing query_id {}", queryId);
-
+                    //HACK: this should be set in the OpenSearch config (to send to the client code just once),
+                    // and not on every single response,
+                    // but that server setting doesn't appear to be exposed.
                     threadPool.getThreadContext().addResponseHeader("Access-Control-Expose-Headers", "query_id");
                     threadPool.getThreadContext().addResponseHeader("query_id", queryId);
 

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -37,6 +37,10 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
     private final Settings settings;
     private final ThreadPool threadPool;
 
+    public Settings getSettings(){
+        return this.settings;
+    }
+
     public UserBehaviorInsightsActionFilter(final Backend backend, final Settings settings, ThreadPool threadPool) {
         this.backend = backend;
         this.settings = settings;
@@ -106,7 +110,8 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
                         LOGGER.error("Unable to persist query.", ex);
                     }
 
-                    LOGGER.warn("######### Setting and exposing query_id {}", queryId);
+                    LOGGER.info("######### Setting and exposing query_id {}", queryId);
+
                     threadPool.getThreadContext().addResponseHeader("Access-Control-Expose-Headers", "query_id");
                     threadPool.getThreadContext().addResponseHeader("query_id", queryId);
 

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -110,9 +110,9 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
                         LOGGER.error("Unable to persist query.", ex);
                     }
 
-                    LOGGER.info("######### Setting and exposing query_id {}", queryId);
+                    LOGGER.info("Setting and exposing query_id {}", queryId);
                     //HACK: this should be set in the OpenSearch config (to send to the client code just once),
-                    // and not on every single response,
+                    // and not on every single search response,
                     // but that server setting doesn't appear to be exposed.
                     threadPool.getThreadContext().addResponseHeader("Access-Control-Expose-Headers", "query_id");
                     threadPool.getThreadContext().addResponseHeader("query_id", queryId);

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
@@ -23,7 +23,6 @@ import org.opensearch.rest.RestRequest;
 import org.opensearch.ubi.HeaderConstants;
 import org.opensearch.ubi.backends.Backend;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
@@ -155,6 +155,7 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
             
 
             final String s = "query_id:" + queryId + "&stores:" + String.join(",", stores);
+            
             BytesRestResponse response = new BytesRestResponse(RestStatus.OK, "application/x-www-form-urlencoded", s);
             response.addHeader("Access-Control-Expose-Headers", "query_id");
             response.addHeader("query_id", queryId);

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
@@ -20,11 +20,15 @@ import org.opensearch.core.rest.RestStatus;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.ubi.HeaderConstants;
 import org.opensearch.ubi.backends.Backend;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
 
 import static org.opensearch.rest.RestRequest.Method.*;
 
@@ -49,13 +53,14 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
                 new Route(PUT, "/_plugins/ubi/{store}"), // Initializes the store.
                 new Route(DELETE, "/_plugins/ubi/{store}"), // Deletes a store.
                 new Route(GET, "/_plugins/ubi"), // Lists all stores
+                new Route(TRACE, "/_plugins/ubi"),          // for debugging rest weirdness
                 new Route(POST, "/_plugins/ubi/{store}")); // Indexes events into the store.
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient nodeClient) {
 
-        LOGGER.log(Level.INFO, "received event");
+        LOGGER.log(Level.INFO, "{}: received event", request.method());
 
         if (request.method() == PUT) {
 
@@ -66,7 +71,7 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
                 return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "missing store name"));
             }
 
-            LOGGER.info("Creating UBL store {}", storeName);
+            LOGGER.info("Creating UBI store {}", storeName);
 
             return (channel) -> {
                 /*if(backend.exists(storeName)) {
@@ -86,7 +91,7 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
                 return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "missing store name"));
             }
 
-            LOGGER.info("Deleting UBL store {}", storeName);
+            LOGGER.info("Deleting UBI store {}", storeName);
 
             return (channel) -> {
                 backend.delete(storeName);
@@ -104,7 +109,7 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
                     return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.NOT_FOUND, "store not found"));
                 }*/
 
-                LOGGER.info("Queuing event for storage into UBL store {}", storeName);
+                LOGGER.info("Queuing event for storage into UBI store {}", storeName);
                 final String eventJson = request.content().utf8ToString();
 
                 try {
@@ -130,7 +135,34 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
 
             return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, s));
 
-        }
+        } else if (request.method() == TRACE) {
+            LOGGER.warn("TRACE ############################################");
+            
+            final Map<String, List<String>> headers = request.getHeaders();
+            LOGGER.info("Exposed headers: " + String.join(",", headers.keySet()));
+            
+            List<String> ids = headers.get(HeaderConstants.QUERY_ID_HEADER.toString());
+            String queryId = null;
+            if(ids == null || ids.size() == 0){
+                LOGGER.warn("Null REST parameter: {}. Using default id.", HeaderConstants.QUERY_ID_HEADER);
+                queryId = UUID.randomUUID().toString();
+            }
+            else {
+                queryId = ids.get(0); 
+            }
+
+            final Set<String> stores = backend.get();
+            
+
+            final String s = "query_id:" + queryId + "&stores:" + String.join(",", stores);
+            BytesRestResponse response = new BytesRestResponse(RestStatus.OK, "application/x-www-form-urlencoded", s);
+            response.addHeader("Access-Control-Expose-Headers", "query_id");
+            response.addHeader("query_id", queryId);
+
+            return (channel) -> channel.sendResponse(response);
+        } 
+        else
+            LOGGER.warn("Unknown method " + request.method());
 
         // TODO: Return a list names of all search_relevance stores.
         return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, "ok"));

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsRestHandler.java
@@ -135,7 +135,7 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
             return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, s));
 
         } else if (request.method() == TRACE) {
-            LOGGER.warn("TRACE ############################################");
+            LOGGER.warn("TRACE");
             
             final Map<String, List<String>> headers = request.getHeaders();
             LOGGER.info("Exposed headers: " + String.join(",", headers.keySet()));

--- a/src/main/java/org/opensearch/ubi/events/AbstractEventManager.java
+++ b/src/main/java/org/opensearch/ubi/events/AbstractEventManager.java
@@ -15,6 +15,7 @@ import org.opensearch.ubi.events.queues.InternalQueue;
 
 public abstract class AbstractEventManager {
 
+    @SuppressWarnings("unused")
     private final Logger LOGGER = LogManager.getLogger(AbstractEventManager.class);
 
     protected final EventQueue eventQueue;

--- a/src/yamlRestTest/resources/rest-api-spec/api/_plugins.ubi.json
+++ b/src/yamlRestTest/resources/rest-api-spec/api/_plugins.ubi.json
@@ -9,6 +9,7 @@
             "DELETE",
             "GET",
             "POST",
+            "TRACE",
             "PUT"
           ]
         }


### PR DESCRIPTION
Added `Access-Control-Expose-Headers` header to allow `query_id` to get past CORS restrictions.
Testing can be done with https://github.com/o19s/ubi_playground/blob/main/tools/stub/cors_test.html.

I'm also leaving in the HTTP `TRACE` verb so that we can do testing without breaking anything else in the plugin.