### PR TITLE
Adding null check for id field setting

### DIFF
--- a/index-chorus-data.sh
+++ b/index-chorus-data.sh
@@ -4,7 +4,7 @@ CHORUS_HOME=`realpath ../chorus-opensearch-edition`
 echo "Using CHORUS_HOME = ${CHORUS_HOME}"
 
 TEMP_FILE=`mktemp`
-head -n 100 ${CHORUS_HOME}/transformed_data.json > ${TEMP_FILE}
+head -n 50 ${CHORUS_HOME}/transformed_data.json > ${TEMP_FILE}
 
 echo "Deleting index"
 curl -s -X DELETE "localhost:9200/ecommerce"

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -107,7 +107,7 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
                             // Add each hit to the list of query responses.
                             for (final SearchHit hit : searchResponse.getHits()) {
 
-                                if ("".equals(idField)) {
+                                if (idField == null || "".equals(idField) || idField.equals("null")) {
 
                                     // Use the _id since there is no id_field setting for this index.
                                     queryResponseHitIds.add(String.valueOf(hit.docId()));


### PR DESCRIPTION
Improving the null check for the `id_field` setting. This follows on to #67. 