### PR TITLE
Caching index settings

### DIFF
--- a/src/main/java/org/opensearch/ubi/UserBehaviorInsightsPlugin.java
+++ b/src/main/java/org/opensearch/ubi/UserBehaviorInsightsPlugin.java
@@ -15,7 +15,11 @@ import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.node.DiscoveryNodes;
 import org.opensearch.cluster.service.ClusterService;
-import org.opensearch.common.settings.*;
+import org.opensearch.common.settings.ClusterSettings;
+import org.opensearch.common.settings.IndexScopedSettings;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.settings.SettingsFilter;
 import org.opensearch.core.common.io.stream.NamedWriteableRegistry;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.env.Environment;
@@ -35,7 +39,12 @@ import org.opensearch.ubi.model.HeaderConstants;
 import org.opensearch.ubi.model.SettingsConstants;
 import org.opensearch.watcher.ResourceWatcherService;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 

--- a/src/main/java/org/opensearch/ubi/UserBehaviorInsightsPlugin.java
+++ b/src/main/java/org/opensearch/ubi/UserBehaviorInsightsPlugin.java
@@ -35,10 +35,7 @@ import org.opensearch.ubi.model.HeaderConstants;
 import org.opensearch.ubi.model.SettingsConstants;
 import org.opensearch.watcher.ResourceWatcherService;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -52,6 +49,8 @@ public class UserBehaviorInsightsPlugin extends Plugin implements ActionPlugin {
     private static final Logger LOGGER = LogManager.getLogger(UserBehaviorInsightsPlugin.class);
 
     private ActionFilter userBehaviorLoggingFilter;
+
+    public static final Map<String, String> storeSettings = new HashMap<>();
 
     @Override
     public Collection<RestHeaderDefinition> getRestHeaders() {

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -181,12 +181,12 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
 
         if(UserBehaviorInsightsPlugin.storeSettings.containsKey(key)) {
 
-            LOGGER.info("Getting setting " + setting + " for store " + storeName + " from the cache.");
+            LOGGER.debug("Getting setting " + setting + " for store " + storeName + " from the cache.");
             value = UserBehaviorInsightsPlugin.storeSettings.get(key);
 
         } else{
 
-            LOGGER.info("Getting setting " + setting + " for store " + storeName + " from the index.");
+            LOGGER.debug("Getting setting " + setting + " for store " + storeName + " from the index.");
 
             // Get the id_field to use for each result's unique identifier.
             final String queriesIndexName = UbiUtils.getQueriesIndexName(storeName);

--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -32,7 +32,12 @@ import org.opensearch.ubi.model.QueryResponse;
 import org.opensearch.ubi.model.SettingsConstants;
 import org.opensearch.ubi.utils.UbiUtils;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 /**
  * An implementation of {@link ActionFilter} that passively listens for OpenSearch

--- a/src/main/java/org/opensearch/ubi/rest/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/org/opensearch/ubi/rest/UserBehaviorInsightsRestHandler.java
@@ -27,6 +27,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.ubi.UserBehaviorInsightsPlugin;
 import org.opensearch.ubi.events.Event;
 import org.opensearch.ubi.events.OpenSearchEventManager;
 import org.opensearch.ubi.model.HeaderConstants;
@@ -219,6 +220,9 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
         final XContentBuilder builder = XContentType.JSON.contentBuilder();
         builder.startObject().field("status", "deleted");
         builder.endObject();
+
+        // Remove this store's settings from the settings map.
+        UserBehaviorInsightsPlugin.storeSettings.entrySet().removeIf(entry -> entry.getKey().startsWith(storeName + "."));
 
         return (channel) -> channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
 

--- a/src/main/java/org/opensearch/ubi/rest/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/org/opensearch/ubi/rest/UserBehaviorInsightsRestHandler.java
@@ -35,9 +35,18 @@ import org.opensearch.ubi.model.SettingsConstants;
 import org.opensearch.ubi.utils.UbiUtils;
 
 import java.io.IOException;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
 
-import static org.opensearch.rest.RestRequest.Method.*;
+import static org.opensearch.rest.RestRequest.Method.DELETE;
+import static org.opensearch.rest.RestRequest.Method.GET;
+import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+import static org.opensearch.rest.RestRequest.Method.TRACE;
 
 /**
  * The REST handler for User Behavior Insights. The handler provides the


### PR DESCRIPTION
For #92, cache index settings to avoid looking at the index to find the settings. This is to avoid unnecessary roundtrips when logging queries.

Upon first query, the settings are retrieved from the index. For queries after that, the setting is retrieved from the cache:

```
opensearch_ubi  | [2024-03-07T18:22:47,815][INFO ][o.o.u.a.UserBehaviorInsightsActionFilter] [opensearch] Getting setting index.ubi.store for store awesome from the cache.
opensearch_ubi  | [2024-03-07T18:22:47,816][INFO ][o.o.u.a.UserBehaviorInsightsActionFilter] [opensearch] Getting setting index.ubi.id_field for store awesome from the cache.
```

After the store is deleted and recreated, the next search will get the settings from the index since the cache has been cleared.

```
opensearch_ubi  | [2024-03-07T18:23:25,851][INFO ][o.o.u.a.UserBehaviorInsightsActionFilter] [opensearch] Getting setting index.ubi.store for store awesome from the index.
opensearch_ubi  | [2024-03-07T18:23:25,853][INFO ][o.o.u.a.UserBehaviorInsightsActionFilter] [opensearch] Getting setting index.ubi.id_field for store awesome from the index.
```