### PR TITLE
Changing group name to be com.o19s

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,12 +7,12 @@ apply plugin: 'maven-publish'
 opensearchplugin {
     name 'opensearch-ubi'
     description 'OpenSearch User Behavior Insights Plugin'
-    classname 'org.opensearch.ubi.UserBehaviorInsightsPlugin'
+    classname 'com.o19s.ubi.UserBehaviorInsightsPlugin'
     licenseFile rootProject.file('LICENSE.txt')
     noticeFile rootProject.file('NOTICE.txt')
 }
 
-group = 'org.opensearch'
+group = 'com.o19s'
 version = "${ubiVersion}-os${opensearchVersion}"
 
 // disabling some unnecessary validations for this plugin
@@ -61,7 +61,7 @@ publishing {
             pom {
                 name = "opensearch-ubi"
                 description = "Provides User Behavior Insights for OpenSearch"
-                groupId = "org.opensearch"
+                groupId = "com.o19s"
                 licenses {
                     license {
                         name = "The Apache License, Version 2.0"

--- a/src/main/java/com/o19s/ubi/UserBehaviorInsightsPlugin.java
+++ b/src/main/java/com/o19s/ubi/UserBehaviorInsightsPlugin.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi;
+package com.o19s.ubi;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -32,11 +32,11 @@ import org.opensearch.rest.RestHandler;
 import org.opensearch.rest.RestHeaderDefinition;
 import org.opensearch.script.ScriptService;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.ubi.action.UserBehaviorInsightsActionFilter;
-import org.opensearch.ubi.rest.UserBehaviorInsightsRestHandler;
-import org.opensearch.ubi.events.OpenSearchEventManager;
-import org.opensearch.ubi.model.HeaderConstants;
-import org.opensearch.ubi.model.SettingsConstants;
+import com.o19s.ubi.action.UserBehaviorInsightsActionFilter;
+import com.o19s.ubi.rest.UserBehaviorInsightsRestHandler;
+import com.o19s.ubi.events.OpenSearchEventManager;
+import com.o19s.ubi.model.HeaderConstants;
+import com.o19s.ubi.model.SettingsConstants;
 import org.opensearch.watcher.ResourceWatcherService;
 
 import java.util.ArrayList;
@@ -59,6 +59,9 @@ public class UserBehaviorInsightsPlugin extends Plugin implements ActionPlugin {
 
     private ActionFilter userBehaviorLoggingFilter;
 
+    /**
+     * A map that caches store settings to avoid round-trip calls to the index.
+     */
     public static final Map<String, String> storeSettings = new HashMap<>();
 
     @Override

--- a/src/main/java/com/o19s/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/com/o19s/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -6,8 +6,14 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.action;
+package com.o19s.ubi.action;
 
+import com.o19s.ubi.UserBehaviorInsightsPlugin;
+import com.o19s.ubi.model.HeaderConstants;
+import com.o19s.ubi.model.QueryRequest;
+import com.o19s.ubi.model.QueryResponse;
+import com.o19s.ubi.model.SettingsConstants;
+import com.o19s.ubi.utils.UbiUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.ActionRequest;
@@ -25,12 +31,6 @@ import org.opensearch.core.action.ActionResponse;
 import org.opensearch.search.SearchHit;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
-import org.opensearch.ubi.UserBehaviorInsightsPlugin;
-import org.opensearch.ubi.model.HeaderConstants;
-import org.opensearch.ubi.model.QueryRequest;
-import org.opensearch.ubi.model.QueryResponse;
-import org.opensearch.ubi.model.SettingsConstants;
-import org.opensearch.ubi.utils.UbiUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;

--- a/src/main/java/com/o19s/ubi/events/AbstractEventManager.java
+++ b/src/main/java/com/o19s/ubi/events/AbstractEventManager.java
@@ -6,12 +6,12 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.events;
+package com.o19s.ubi.events;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ubi.events.queues.EventQueue;
-import org.opensearch.ubi.events.queues.InternalQueue;
+import com.o19s.ubi.events.queues.EventQueue;
+import com.o19s.ubi.events.queues.InternalQueue;
 
 /**
  * Base class for managing client-side events.

--- a/src/main/java/com/o19s/ubi/events/Event.java
+++ b/src/main/java/com/o19s/ubi/events/Event.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.events;
+package com.o19s.ubi.events;
 
 /**
  * A client-side event.

--- a/src/main/java/com/o19s/ubi/events/OpenSearchEventManager.java
+++ b/src/main/java/com/o19s/ubi/events/OpenSearchEventManager.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.events;
+package com.o19s.ubi.events;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/com/o19s/ubi/events/queues/EventQueue.java
+++ b/src/main/java/com/o19s/ubi/events/queues/EventQueue.java
@@ -6,9 +6,9 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.events.queues;
+package com.o19s.ubi.events.queues;
 
-import org.opensearch.ubi.events.Event;
+import com.o19s.ubi.events.Event;
 
 import java.util.List;
 

--- a/src/main/java/com/o19s/ubi/events/queues/InternalQueue.java
+++ b/src/main/java/com/o19s/ubi/events/queues/InternalQueue.java
@@ -6,9 +6,9 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.events.queues;
+package com.o19s.ubi.events.queues;
 
-import org.opensearch.ubi.events.Event;
+import com.o19s.ubi.events.Event;
 
 import java.util.LinkedList;
 import java.util.List;

--- a/src/main/java/com/o19s/ubi/model/HeaderConstants.java
+++ b/src/main/java/com/o19s/ubi/model/HeaderConstants.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.model;
+package com.o19s.ubi.model;
 
 /**
  * HTTP headers used by the plugin.

--- a/src/main/java/com/o19s/ubi/model/QueryRequest.java
+++ b/src/main/java/com/o19s/ubi/model/QueryRequest.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.model;
+package com.o19s.ubi.model;
 
 /**
  * A query received by OpenSearch.

--- a/src/main/java/com/o19s/ubi/model/QueryResponse.java
+++ b/src/main/java/com/o19s/ubi/model/QueryResponse.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.model;
+package com.o19s.ubi.model;
 
 import java.util.List;
 

--- a/src/main/java/com/o19s/ubi/model/SettingsConstants.java
+++ b/src/main/java/com/o19s/ubi/model/SettingsConstants.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.model;
+package com.o19s.ubi.model;
 
 /**
  * Settings constants used by the plugin.

--- a/src/main/java/com/o19s/ubi/rest/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/com/o19s/ubi/rest/UserBehaviorInsightsRestHandler.java
@@ -6,12 +6,16 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.rest;
+package com.o19s.ubi.rest;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.o19s.ubi.UserBehaviorInsightsPlugin;
+import com.o19s.ubi.events.Event;
+import com.o19s.ubi.model.HeaderConstants;
+import com.o19s.ubi.model.SettingsConstants;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -27,12 +31,8 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
-import org.opensearch.ubi.UserBehaviorInsightsPlugin;
-import org.opensearch.ubi.events.Event;
-import org.opensearch.ubi.events.OpenSearchEventManager;
-import org.opensearch.ubi.model.HeaderConstants;
-import org.opensearch.ubi.model.SettingsConstants;
-import org.opensearch.ubi.utils.UbiUtils;
+import com.o19s.ubi.events.OpenSearchEventManager;
+import com.o19s.ubi.utils.UbiUtils;
 
 import java.io.IOException;
 import java.util.HashSet;

--- a/src/main/java/com/o19s/ubi/utils/UbiUtils.java
+++ b/src/main/java/com/o19s/ubi/utils/UbiUtils.java
@@ -6,7 +6,7 @@
  * compatible open source license.
  */
 
-package org.opensearch.ubi.utils;
+package com.o19s.ubi.utils;
 
 import org.opensearch.common.util.io.Streams;
 


### PR DESCRIPTION
For #101 and to support #95, changing the group name from `org.opensearch` to `com.o19s`. 