### PR TITLE
Adding literal 'null' check.

### DIFF
--- a/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
+++ b/src/main/java/org/opensearch/ubi/action/UserBehaviorInsightsActionFilter.java
@@ -213,7 +213,7 @@ public class UserBehaviorInsightsActionFilter implements ActionFilter {
 
         final String value = task.getHeader(header.getHeader());
 
-        if(value == null || value.trim().isEmpty()) {
+        if(value == null || value.trim().isEmpty() || value.equals("null")) {
             return defaultValue;
         } else {
             return value;


### PR DESCRIPTION
Adding literal 'null' check for #106.

I'm on the fence if a literal string value of `"null"` should be considered equal to a `null` value, but this change ignores the query ID if the literal value of `"null"` is received and instead generates a new query ID.

To test:

```
./gradlew build
docker-compose build && docker compose up
./index-chorus-data.sh 

curl -X PUT "http://localhost:9200/_plugins/ubi/awesome?index=ecommerce&id_field=name"
curl -vvvv http://localhost:9200/ecommerce/_search -H "X-ubi-store: awesome" -H "X-ubi-query-id: null" 
```

Output:

```
*   Trying 127.0.0.1:9200...
* Connected to localhost (127.0.0.1) port 9200 (#0)
> GET /ecommerce/_search HTTP/1.1
> Host: localhost:9200
> User-Agent: curl/7.81.0
> Accept: */*
> X-ubi-store: awesome
> X-ubi-query-id: null
> 
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< query_id: 5d403d69-c5ee-4d33-ac24-8571c2a31f2c                <----- a query ID was assigned
< Access-Control-Expose-Headers: query_id
< content-type: application/json; charset=UTF-8
< content-length: 16012
```