### PR TITLE
Improving the getting of indexes

### DIFF
--- a/src/yamlRestTest/resources/rest-api-spec/test/_plugins.ubi/10_manage.yml
+++ b/src/yamlRestTest/resources/rest-api-spec/test/_plugins.ubi/10_manage.yml
@@ -9,19 +9,19 @@
       indices.exists:
         index: .mystore_events
 
-#  - match: { created }
-#
-#  - do:
-#      ubi.get_stores: {}
-#
-#  - match: { mystore }
-#
-#  - do:
-#      ubi.delete_store:
-#        store: mystore
-#
-#  - do:
-#      indices.exists:
-#        index: .mystore_events
-#
-#  - is_false: ''
+  - match: { created }
+
+  - do:
+      ubi.get_stores: {}
+
+  - match: { mystore }
+
+  - do:
+      ubi.delete_store:
+        store: mystore
+
+  - do:
+      indices.exists:
+        index: .mystore_events
+
+  - is_false: ''


### PR DESCRIPTION
Improving the getting of indexes and re-enabling the yaml rest test to get stores.

To test:

```
curl -X PUT localhost:9200/_plugins/ubi/mystore
curl -X PUT localhost:9200/_plugins/ubi/mystor2
curl -X GET localhost:9200/_plugins/ubi/
```

Response:

```
{"stores":["mystore","mystore2"]}
```