### PR TITLE
Changing scheduler to fixed delay and separating events and queries tasks

### DIFF
--- a/load-test/run.sh
+++ b/load-test/run.sh
@@ -10,7 +10,7 @@ curl -X PUT "http://localhost:9200/_plugins/ubi/mystore?index=ecommerce"
 ../index-chorus-data.sh `realpath ../../chorus-opensearch-edition`
 
 # Insert events and queries.
-locust -f load-test.py --headless -u 1 -r 1 --run-time 30s --host http://localhost:9200
+locust -f load-test.py --headless -u 1 -r 1 --run-time 600s --host http://localhost:9200
 
 # Let events index.
 sleep 10

--- a/src/main/java/com/o19s/ubi/OpenSearchEventManager.java
+++ b/src/main/java/com/o19s/ubi/OpenSearchEventManager.java
@@ -37,7 +37,7 @@ public class OpenSearchEventManager extends EventManager {
     }
 
     @Override
-    public void process() {
+    public void processEvents() {
 
         if(eventsQueue.size() > 0) {
 
@@ -57,6 +57,11 @@ public class OpenSearchEventManager extends EventManager {
             client.bulk(eventsBulkRequest);
 
         }
+
+    }
+
+    @Override
+    public void processQueries() {
 
         if(queryRequestsQueue.size() > 0) {
 
@@ -104,6 +109,7 @@ public class OpenSearchEventManager extends EventManager {
     @Override
     public void add(final QueryRequest queryRequest) {
         queryRequestsQueue.add(queryRequest);
+        LOGGER.info("Size of queryRequestsQueue " + queryRequestsQueue.size());
     }
 
     /**

--- a/src/main/java/com/o19s/ubi/OpenSearchEventManager.java
+++ b/src/main/java/com/o19s/ubi/OpenSearchEventManager.java
@@ -42,7 +42,7 @@ public class OpenSearchEventManager extends EventManager {
         if(eventsQueue.size() > 0) {
 
             final BulkRequest eventsBulkRequest = new BulkRequest();
-            LOGGER.info("Bulk inserting " + eventsQueue.size() + " UBI events");
+            LOGGER.debug("Bulk inserting " + eventsQueue.size() + " UBI events");
 
             for (final Event event : eventsQueue.get()) {
 
@@ -66,11 +66,11 @@ public class OpenSearchEventManager extends EventManager {
         if(queryRequestsQueue.size() > 0) {
 
             final BulkRequest queryRequestsBulkRequest = new BulkRequest();
-            LOGGER.info("Bulk inserting " + queryRequestsQueue.size() + " UBI queries");
+            LOGGER.debug("Bulk inserting " + queryRequestsQueue.size() + " UBI queries");
 
             for(final QueryRequest queryRequest : queryRequestsQueue.get()) {
 
-                LOGGER.info("Writing query ID {} with response ID {}",
+                LOGGER.debug("Writing query ID {} with response ID {}",
                         queryRequest.getQueryId(), queryRequest.getQueryResponse().getQueryResponseId());
 
                 // What will be indexed - adheres to the queries-mapping.json
@@ -109,7 +109,6 @@ public class OpenSearchEventManager extends EventManager {
     @Override
     public void add(final QueryRequest queryRequest) {
         queryRequestsQueue.add(queryRequest);
-        LOGGER.info("Size of queryRequestsQueue " + queryRequestsQueue.size());
     }
 
     /**

--- a/src/main/java/com/o19s/ubi/UserBehaviorInsightsPlugin.java
+++ b/src/main/java/com/o19s/ubi/UserBehaviorInsightsPlugin.java
@@ -120,13 +120,16 @@ public class UserBehaviorInsightsPlugin extends Plugin implements ActionPlugin {
             Supplier<RepositoriesService> repositoriesServiceSupplier
     ) {
 
-        // TODO Only start this if an OpenSearch store is already initialized.
-        // Otherwise, start it when a store is initialized.
+        // TODO: Allow the parameters of the scheduled tasks to be configurable.
 
         LOGGER.info("Creating UBI scheduled task to persist events.");
-        // TODO: Allow these time parameters to be configurable.
-        threadPool.scheduler().scheduleAtFixedRate(() -> {
-            OpenSearchEventManager.getInstance(client).process();
+        threadPool.scheduler().scheduleWithFixedDelay(() -> {
+            OpenSearchEventManager.getInstance(client).processEvents();
+        }, 0, 2000, TimeUnit.MILLISECONDS);
+
+        LOGGER.info("Creating UBI scheduled task to persist queries.");
+        threadPool.scheduler().scheduleWithFixedDelay(() -> {
+            OpenSearchEventManager.getInstance(client).processQueries();
         }, 0, 2000, TimeUnit.MILLISECONDS);
 
         // Initialize the action filter.

--- a/src/main/java/com/o19s/ubi/events/EventManager.java
+++ b/src/main/java/com/o19s/ubi/events/EventManager.java
@@ -41,9 +41,14 @@ public abstract class EventManager {
     }
 
     /**
-     * Process the items on the queue by writing them to persistent storage.
+     * Process the events on the queue by writing them to persistent storage.
      */
-    public abstract void process();
+    public abstract void processEvents();
+
+    /**
+     * Process the queries on the queue by writing them to persistent storage.
+     */
+    public abstract void processQueries();
 
     /**
      * Add an event to the queue.


### PR DESCRIPTION
Changing scheduler to fixed delay because that's a better fit and separating events and queries tasks so they can process independently.

Small test to verify counts of events and queries:

```
Type     Name                                                                          # reqs      # fails |    Avg     Min     Max    Med |   req/s  failures/s
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
POST     /_plugins/ubi/mystore                                                            208     0(0.00%) |      4       2       8      5 |    0.35        0.00
GET      /ecommerce/_search                                                               188     0(0.00%) |      7       4      24      8 |    0.31        0.00
--------|----------------------------------------------------------------------------|-------|-------------|-------|-------|-------|-------|--------|-----------
         Aggregated                                                                       396     0(0.00%) |      6       2      24      6 |    0.66        0.00
```

```
Found 208 events
Found 188 queries
```