### PR TITLE
Adding docker-compose for OpenSearch three node cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ Found 8 indexed
 ```
 
 This shows 8 total requests made by locust, and 8 events are in the index. The idea being we can assert that the number of events sent matches the events stored in the index.
+
+## Starting up a Multi Node Cluster
+
+To start up a three node cluster run `docker compose -f Dockerfile.prod up`

--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -1,0 +1,92 @@
+version: '3.7'
+
+services:
+
+  os01:
+    build: ./
+    environment:
+      node.name: os01
+      discovery.seed_hosts: os01,os02,os03
+      cluster.initial_master_nodes: os01,os02,os03
+      plugins.security.disabled: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
+      JAVA_HOME: /usr/share/opensearch/jdk
+      network.host: "0.0.0.0"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    volumes:
+      - "./opensearch-cluster.yml:/usr/share/opensearch/config/opensearch.yml"
+      - "os-data1:/usr/share/opensearch/data"
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "1"
+    ports:
+      - 9200:9200
+      - 9600:9600
+  
+  os02:
+    build: ./
+    environment:
+      node.name: os02
+      discovery.seed_hosts: os01,os02,os03
+      cluster.initial_master_nodes: os01,os02,os03
+      plugins.security.disabled: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
+      JAVA_HOME: /usr/share/opensearch/jdk
+      network.host: "0.0.0.0"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "1"
+    volumes:
+      - "./opensearch-cluster.yml:/usr/share/opensearch/config/opensearch.yml"
+      - "os-data2:/usr/share/opensearch/data"
+  
+  os03:
+    build: ./
+    environment:
+      node.name: os03
+      discovery.seed_hosts: os01,os02,os03
+      cluster.initial_master_nodes: os01,os02,os03
+      plugins.security.disabled: "true"
+      DISABLE_INSTALL_DEMO_CONFIG: "true"
+      JAVA_HOME: /usr/share/opensearch/jdk
+      network.host: "0.0.0.0"
+      OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536
+        hard: 65536
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "100m"
+        max-file: "1"
+    volumes:
+      - "./opensearch-cluster.yml:/usr/share/opensearch/config/opensearch.yml"
+      - "os-data3:/usr/share/opensearch/data"
+
+volumes:
+  os-data1:
+  os-data2:
+  os-data3:

--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -11,8 +11,9 @@ services:
       plugins.security.disabled: "true"
       DISABLE_INSTALL_DEMO_CONFIG: "true"
       JAVA_HOME: /usr/share/opensearch/jdk
-      network.host: "0.0.0.0"
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
+      cluster.name: os-cluster
+      network.host: 0.0.0.0
     ulimits:
       memlock:
         soft: -1
@@ -20,14 +21,6 @@ services:
       nofile:
         soft: 65536
         hard: 65536
-    volumes:
-      - "./opensearch-cluster.yml:/usr/share/opensearch/config/opensearch.yml"
-      - "os-data1:/usr/share/opensearch/data"
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-        max-file: "1"
     ports:
       - 9200:9200
       - 9600:9600
@@ -41,8 +34,9 @@ services:
       plugins.security.disabled: "true"
       DISABLE_INSTALL_DEMO_CONFIG: "true"
       JAVA_HOME: /usr/share/opensearch/jdk
-      network.host: "0.0.0.0"
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
+      cluster.name: os-cluster
+      network.host: 0.0.0.0
     ulimits:
       memlock:
         soft: -1
@@ -50,15 +44,7 @@ services:
       nofile:
         soft: 65536
         hard: 65536
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-        max-file: "1"
-    volumes:
-      - "./opensearch-cluster.yml:/usr/share/opensearch/config/opensearch.yml"
-      - "os-data2:/usr/share/opensearch/data"
-  
+
   os03:
     build: ./
     environment:
@@ -68,8 +54,9 @@ services:
       plugins.security.disabled: "true"
       DISABLE_INSTALL_DEMO_CONFIG: "true"
       JAVA_HOME: /usr/share/opensearch/jdk
-      network.host: "0.0.0.0"
       OPENSEARCH_INITIAL_ADMIN_PASSWORD: SuperSecretPassword_123
+      cluster.name: os-cluster
+      network.host: 0.0.0.0
     ulimits:
       memlock:
         soft: -1
@@ -77,16 +64,3 @@ services:
       nofile:
         soft: 65536
         hard: 65536
-    logging:
-      driver: "json-file"
-      options:
-        max-size: "100m"
-        max-file: "1"
-    volumes:
-      - "./opensearch-cluster.yml:/usr/share/opensearch/config/opensearch.yml"
-      - "os-data3:/usr/share/opensearch/data"
-
-volumes:
-  os-data1:
-  os-data2:
-  os-data3:

--- a/docker-compose-cluster.yaml
+++ b/docker-compose-cluster.yaml
@@ -64,3 +64,16 @@ services:
       nofile:
         soft: 65536
         hard: 65536
+
+  os-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.12.0
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601
+    expose:
+      - 5601
+    environment:
+      OPENSEARCH_HOSTS: '["http://os01:9200"]'
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
+    depends_on:
+      - os01

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,9 +1,9 @@
 version: '3'
 
 services:
-  opensearch:
+  ubi-dev-os:
     build: ./
-    container_name: opensearch_ubi 
+    container_name: ubi-dev-os 
     environment:
       discovery.type: single-node
       node.name: opensearch
@@ -32,25 +32,23 @@ services:
       - 9200
       - 9600
     networks:
-      - opensearch-net
+      - ubi-dev-os-net
 
-  # opensearch-dashboards:
-  #   build: ./dashboard-plugin/
-  #   container_name: opensearch-dashboards
-  #   ports:
-  #     - 5601:5601
-  #   expose:
-  #     - 5601
-  #   environment:
-  #     OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
-  #   networks:
-  #     - opensearch-net
-  #   depends_on:
-  #     - opensearch
-
-volumes:
-  opensearch-data:
+  ubi-dev-os-dashboards:
+    image: opensearchproject/opensearch-dashboards:2.12.0
+    container_name: ubi-dev-os-dashboards
+    ports:
+      - 5601:5601
+    expose:
+      - 5601
+    environment:
+      OPENSEARCH_HOSTS: '["http://ubi-dev-os:9200"]'
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
+    depends_on:
+      - ubi-dev-os
+    networks:
+      - ubi-dev-os-net      
 
 networks:
-  opensearch-net:
+  ubi-dev-os-net:
     driver: bridge

--- a/opensearch-cluster.yml
+++ b/opensearch-cluster.yml
@@ -1,0 +1,8 @@
+cluster.name: os-cluster
+network.host: 0.0.0.0
+
+bootstrap.memory_lock: "true" # along with the memlock settings below, disables swapping
+
+cluster.routing.allocation.disk.threshold_enabled: true
+cluster.routing.allocation.disk.watermark.low: 93%
+cluster.routing.allocation.disk.watermark.high: 95%

--- a/opensearch-cluster.yml
+++ b/opensearch-cluster.yml
@@ -1,8 +1,0 @@
-cluster.name: os-cluster
-network.host: 0.0.0.0
-
-bootstrap.memory_lock: "true" # along with the memlock settings below, disables swapping
-
-cluster.routing.allocation.disk.threshold_enabled: true
-cluster.routing.allocation.disk.watermark.low: 93%
-cluster.routing.allocation.disk.watermark.high: 95%


### PR DESCRIPTION
Adding docker-compose for OpenSearch three node cluster. This is to better support testing on a cluster vs a single node.