### PR TITLE
#146 Logging bulk indexing failures

### DIFF
--- a/src/main/java/com/o19s/ubi/rest/UserBehaviorInsightsRestHandler.java
+++ b/src/main/java/com/o19s/ubi/rest/UserBehaviorInsightsRestHandler.java
@@ -286,7 +286,7 @@ public class UserBehaviorInsightsRestHandler extends BaseRestHandler {
 
     private String setEventTimestamp(final String eventJson) throws JsonProcessingException {
 
-        LOGGER.info("event json: " + eventJson);
+        LOGGER.trace("Received UBI event json: " + eventJson);
 
         final JsonNode rootNode = new ObjectMapper().readTree(eventJson);
 


### PR DESCRIPTION
For #146, a message will be written to the log for events and queries that cannot be indexed. The log will be written with the `WARN` level.

An example log when indexing an event with malformed JSON:

```
ubi-dev-os             | [2024-03-27T16:02:53,154][WARN ][c.o.u.d.OpenSearchDataManager] [opensearch] Unable to insert UBI event: MapperParsingException[failed to parse field [event_attributes.object.description] of type [text] in document with id 'uoumgI4BCWe8J-_LaL9V'. Preview of field's value: '{size=0, query={bool={must=[{bool={must=[{bool={should=[{terms={supplier=[HP]}}]}}]}}]}}, _source={excludes=[], includes=[*]}, aggs={filter_product_type={terms={field=filter_product_type, size=20, order={_count=desc}}}}}']; nested: IllegalStateException[Can't get text on a START_OBJECT at 1:384];
```