### PR TITLE
Automatically draft release notes

### DIFF
--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -1,0 +1,41 @@
+# The overall template of the release notes
+template: |
+  Compatible with OpenSearch 2.12.0.
+  $CHANGES
+
+# Setting the formatting and sorting for the release notes body
+name-template: Version (set version here)
+change-template: '* $TITLE ([#$NUMBER]($URL))'
+sort-by: merged_at
+sort-direction: ascending
+replacers:
+  - search: '##'
+    replace: '###'
+
+categories:
+  - title: 'Breaking Changes'
+    labels:
+      - 'breaking change'
+  - title: 'Features'
+    labels:
+      - 'feature'
+  - title: 'Enhancements'
+    labels:
+      - 'enhancement'
+  - title: 'Bug Fixes'
+    labels:
+      - 'bug'
+  - title: 'Infrastructure'
+    labels:
+      - 'build'
+      - 'testing'
+  - title: 'Documentation'
+    labels:
+      - 'documentation'
+  - title: 'Maintenance'
+    labels:
+      - 'version compatibility'
+      - 'maintenance'
+  - title: 'Refactoring'
+    labels:
+      - 'refactor'

--- a/.github/draft-release-notes-config.yml
+++ b/.github/draft-release-notes-config.yml
@@ -4,7 +4,7 @@ template: |
   $CHANGES
 
 # Setting the formatting and sorting for the release notes body
-name-template: Version (set version here)
+name-template: Version 0.0.11
 change-template: '* $TITLE ([#$NUMBER]($URL))'
 sort-by: merged_at
 sort-direction: ascending

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -1,0 +1,20 @@
+name: Draft Release Notes
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  update_release_draft:
+    name: Update draft release notes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update draft release notes
+        uses: release-drafter/release-drafter@v5
+        with:
+          config-name: draft-release-notes-config.yml
+          name: Version (set here)
+          tag: (None)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/draft-release-notes.yml
+++ b/.github/workflows/draft-release-notes.yml
@@ -14,7 +14,7 @@ jobs:
         uses: release-drafter/release-drafter@v5
         with:
           config-name: draft-release-notes-config.yml
-          name: Version (set here)
-          tag: (None)
+          name: Version 0.0.11
+          tag: 0.0.11
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This may need some tinkering after merge and we see what it produces for the next release.

Taken from the opensearch-plugins project [config](https://github.com/opensearch-project/opensearch-plugins/blob/main/.github/workflows/draft-release-notes.yml).